### PR TITLE
Add config for module index

### DIFF
--- a/resources/config/settings/sections.php
+++ b/resources/config/settings/sections.php
@@ -14,6 +14,7 @@ return [
                 'fields' => [
                     'permalink_structure',
                     'module_segment',
+                    'enable_index',
                     'category_segment',
                     'tag_segment'
                 ]

--- a/resources/config/settings/settings.php
+++ b/resources/config/settings/settings.php
@@ -27,6 +27,12 @@ return [
             'default_value' => 'posts'
         ]
     ],
+    'enable_index' => [
+        'type'   => 'anomaly.field_type.boolean',
+        'config' => [
+            'default_value' => 1,
+        ]
+    ],
     'category_segment'    => [
         'type'     => 'anomaly.field_type.text',
         'required' => true,

--- a/resources/lang/en/setting.php
+++ b/resources/lang/en/setting.php
@@ -9,6 +9,10 @@ return [
         'label'        => 'Module Segment',
         'instructions' => 'Define a custom segment URI for the the Posts module.'
     ],
+    'enable_index'      => [
+        'label'        => 'Enable the module\'s index route',
+        'instructions' => 'When enabled an index of all post entries will be displayed when visiting the module segment URL.'
+    ],
     'category_segment'    => [
         'label'        => 'Category Segment',
         'instructions' => 'Define a custom category segment URI for the category URLs.'

--- a/src/Http/Controller/CategoriesController.php
+++ b/src/Http/Controller/CategoriesController.php
@@ -6,6 +6,7 @@ use Anomaly\PostsModule\Category\Contract\CategoryRepositoryInterface;
 use Anomaly\PostsModule\Post\Command\AddPostsBreadcrumb;
 use Anomaly\PostsModule\Post\Contract\PostRepositoryInterface;
 use Anomaly\Streams\Platform\Http\Controller\PublicController;
+use Anomaly\SettingsModule\Setting\Contract\SettingRepositoryInterface;
 
 /**
  * Class CategoriesController
@@ -26,7 +27,7 @@ class CategoriesController extends PublicController
      * @param                             $category
      * @return \Illuminate\View\View
      */
-    public function index(CategoryRepositoryInterface $categories, PostRepositoryInterface $posts, $category)
+    public function index(CategoryRepositoryInterface $categories, PostRepositoryInterface $posts, SettingRepositoryInterface $settings, $category)
     {
         if (!$category = $categories->findBySlug($category)) {
             abort(404);
@@ -36,7 +37,7 @@ class CategoriesController extends PublicController
         $this->dispatch(new AddCategoryBreadcrumb($category));
         $this->dispatch(new AddCategoryMetaTitle($category));
 
-        $posts = $posts->findManyByCategory($category);
+        $posts = $posts->findManyByCategory($category, $settings->value('anomaly.module.posts::posts_per_page',null));
 
         return view('anomaly.module.posts::categories/index', compact('category', 'posts'));
     }

--- a/src/Http/Controller/PostsController.php
+++ b/src/Http/Controller/PostsController.php
@@ -29,8 +29,12 @@ class PostsController extends PublicController
      * @param PostRepositoryInterface $posts
      * @return \Illuminate\View\View
      */
-    public function index(PostRepositoryInterface $posts)
+    public function index(PostRepositoryInterface $posts, SettingRepositoryInterface $settings)
     {
+        if (!$settings->value('anomaly.module.posts::enable_index',true)) {
+            abort(404);
+        }
+        
         $posts = $posts->getRecent();
 
         $this->dispatch(new AddPostsBreadcrumb());

--- a/src/Http/Controller/PostsController.php
+++ b/src/Http/Controller/PostsController.php
@@ -35,7 +35,7 @@ class PostsController extends PublicController
             abort(404);
         }
         
-        $posts = $posts->getRecent();
+        $posts = $posts->getRecent($settings->value('anomaly.module.posts::posts_per_page',null));
 
         $this->dispatch(new AddPostsBreadcrumb());
         $this->dispatch(new AddPostsMetaTitle());

--- a/src/Http/Controller/TagsController.php
+++ b/src/Http/Controller/TagsController.php
@@ -5,6 +5,7 @@ use Anomaly\PostsModule\Post\Contract\PostRepositoryInterface;
 use Anomaly\PostsModule\Tag\Command\AddTagBreadcrumb;
 use Anomaly\PostsModule\Tag\Command\AddTagMetaTitle;
 use Anomaly\Streams\Platform\Http\Controller\PublicController;
+use Anomaly\SettingsModule\Setting\Contract\SettingRepositoryInterface;
 
 /**
  * Class TagsController
@@ -24,9 +25,9 @@ class TagsController extends PublicController
      * @param                         $tag
      * @return \Illuminate\View\View
      */
-    public function index(PostRepositoryInterface $posts, $tag)
+    public function index(PostRepositoryInterface $posts, SettingRepositoryInterface $settings, $tag)
     {
-        $posts = $posts->findManyByTag($tag);
+        $posts = $posts->findManyByTag($tag,$settings->value('anomaly.module.posts::posts_per_page',null));
 
         $this->dispatch(new AddPostsBreadcrumb());
         $this->dispatch(new AddTagBreadcrumb($tag));

--- a/src/Http/Controller/TypesController.php
+++ b/src/Http/Controller/TypesController.php
@@ -6,6 +6,7 @@ use Anomaly\PostsModule\Type\Command\AddTypeBreadcrumb;
 use Anomaly\PostsModule\Type\Command\AddTypeMetaTitle;
 use Anomaly\PostsModule\Type\Contract\TypeRepositoryInterface;
 use Anomaly\Streams\Platform\Http\Controller\PublicController;
+use Anomaly\SettingsModule\Setting\Contract\SettingRepositoryInterface;
 
 /**
  * Class TypesController
@@ -26,7 +27,7 @@ class TypesController extends PublicController
      * @param                             $type
      * @return \Illuminate\View\View
      */
-    public function index(TypeRepositoryInterface $categories, PostRepositoryInterface $posts, $type)
+    public function index(TypeRepositoryInterface $categories, PostRepositoryInterface $posts, SettingRepositoryInterface $settings, $type)
     {
         if (!$type = $categories->findBySlug($type)) {
             abort(404);
@@ -36,7 +37,7 @@ class TypesController extends PublicController
         $this->dispatch(new AddTypeBreadcrumb($type));
         $this->dispatch(new AddTypeMetaTitle($type));
 
-        $posts = $posts->findManyByType($type);
+        $posts = $posts->findManyByType($type,$settings->value('anomaly.module.posts::posts_per_page',null));
 
         return view('anomaly.module.posts::types/index', compact('type', 'posts'));
     }

--- a/src/Post/Command/GetPostPath.php
+++ b/src/Post/Command/GetPostPath.php
@@ -61,9 +61,9 @@ class GetPostPath implements SelfHandling
         $permalink = implode('}/{', $permalink);
 
         $data = [
-            'year'  => $this->post->created_at->format('Y'),
-            'month' => $this->post->created_at->format('m'),
-            'day'   => $this->post->created_at->format('d'),
+            'year'  => $this->post->publish_at->format('Y'),
+            'month' => $this->post->publish_at->format('m'),
+            'day'   => $this->post->publish_at->format('d'),
             'post'  => $this->post->getSlug()
         ];
 

--- a/src/Post/PostRepository.php
+++ b/src/Post/PostRepository.php
@@ -54,7 +54,7 @@ class PostRepository extends EntryRepository implements PostRepositoryInterface
      */
     public function findBySlug($slug)
     {
-        return $this->model->orderBy('created_at', 'DESC')->where('slug', $slug)->first();
+        return $this->model->orderBy('publish_at', 'DESC')->where('slug', $slug)->first();
     }
 
     /**

--- a/src/PostsModuleServiceProvider.php
+++ b/src/PostsModuleServiceProvider.php
@@ -40,8 +40,7 @@ class PostsModuleServiceProvider extends AddonServiceProvider
         'admin/posts/fields/choose'                             => 'Anomaly\PostsModule\Http\Controller\Admin\FieldsController@choose',
         'admin/posts/fields/create'                             => 'Anomaly\PostsModule\Http\Controller\Admin\FieldsController@create',
         'admin/posts/fields/edit/{id}'                          => 'Anomaly\PostsModule\Http\Controller\Admin\FieldsController@edit',
-        'admin/posts/ajax/choose_type'                          => 'Anomaly\PostsModule\Http\Controller\Admin\AjaxController@chooseType',
-        'admin/posts/settings'                                  => 'Anomaly\PostsModule\Http\Controller\Admin\SettingsController@edit'
+        'admin/posts/ajax/choose_type'                          => 'Anomaly\PostsModule\Http\Controller\Admin\AjaxController@chooseType'
     ];
 
     /**


### PR DESCRIPTION
Added an option to enable or disable the posts module index.  When a user has defined post types they would typically want this index to be disabled.  Left as boolean instead of checkbox as booleans will be changing and the mode param could presumably go away.  Made it "enable_index" instead of "disable_index".  Default value is enabled. 

Added in settings to each controller to enable pagination

Changed post path to use publish_at instead of created_at to make it consistent with the rest of the module.