### PR TITLE
Fixes exception in publish_at date when creating new post

### DIFF
--- a/src/Post/Form/PostFormFields.php
+++ b/src/Post/Form/PostFormFields.php
@@ -1,5 +1,6 @@
 <?php namespace Anomaly\PostsModule\Post\Form;
 
+use Carbon\Carbon;
 use Illuminate\Auth\Guard;
 
 /**
@@ -31,7 +32,7 @@ class PostFormFields
                 ],
                 'publish_at' => [
                     'config' => [
-                        'default_value' => 'now'
+                        'default_value' => Carbon::now()
                     ]
                 ]
             ]


### PR DESCRIPTION
Carbon was throwing an exception in https://github.com/anomalylabs/datetime-field_type/blob/master/src/DatetimeFieldTypeModifier.php#L52 when passing 'now' as a string. Using a Carbon instance instead