### PR TITLE
Use correct references to site config

### DIFF
--- a/resources/views/posts/rss.twig
+++ b/resources/views/posts/rss.twig
@@ -1,7 +1,7 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
-        <title>{{ config('streams::distribution.name') }}</title>
-        <description>{{ config('streams::distribution.description') }}</description>
+        <title>{{ config('app.name') }}</title>
+        <description>{{ config('app.description') }}</description>
         <link>{{ url('/') }}</link>
         <atom:link href="{{ url_current() }}" rel="self" type="application/rss+xml"/>
         {% for post in posts %}


### PR DESCRIPTION
NOTE: This change is dependent on https://github.com/anomalylabs/streams-platform/pull/293 otherwise `config('app.description')` will just return null.

The `rss.xml` references the streams distribution name and description so it never gets overridden when a user changes their site name and description in the admin panel.

This changes that so it grabs the config values for `app.name` and `app.description` which take the ones set via the admin panel or the stream distribution ones as fallback.