### PR TITLE
Added recent scope

### DIFF
--- a/src/Post/PostModel.php
+++ b/src/Post/PostModel.php
@@ -76,6 +76,17 @@ class PostModel extends PostsPostsEntryModel implements PostInterface
     }
 
     /**
+     * Restrict to recent posts only.
+     *
+     * @param  Builder $query
+     * @return Builder
+     */
+    public function scopeRecent(Builder $query)
+    {
+        return $query->live();
+    }
+
+    /**
      * Make the page.
      *
      * @return $this


### PR DESCRIPTION
`anomaly.module.posts::categories/index` is not using an EntryCriteria but the model relation directly.

```twig
{% set posts = category.posts().recent().paginate() %}

// category.posts() is a HasMany relation
```

 As result it show no posts, because the `recent()` exists only on `PostCriteria`. 

PS: I didn't change `scopeLive()` to match the Criteria for B/C. But I think the `v2.5` should have the same behaviour for both.